### PR TITLE
Bug at line 31 due to line 27

### DIFF
--- a/BubbleSort_Enhanced.vb
+++ b/BubbleSort_Enhanced.vb
@@ -28,7 +28,8 @@ Module Module1
         Loop Until swapped = False
 
         'Print out the elements
-        For count = 1 To maxsize
+For count = 1 To height.Length - 1 'maxsize at line 27 reduces, hence giving less number of outpurs
+                                    'thats why height.Length - 1 is added :)
             Console.WriteLine(count & ": " & height(count))
         Next
         Console.ReadKey()


### PR DESCRIPTION
e.g if the array is {9,8,7,6,5}, after the array is sorted, maxsize becomes 0 (line 27). that is why the for loop at line 31 will never run.
the proposed change eliminates this error